### PR TITLE
feat: add import-blacklist tslint rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -355,5 +355,9 @@ module.exports = {
      * Disallows variable names like `any`, `Number`, `string` etc.
      */
     'variable-name': [true, 'ban-keywords'],
+    /**
+     * Disallows imports of specified modules. Instead, sub-path imports should be used for these modules.
+     */
+    'import-blacklist': [true, 'lodash', 'date-fns', '@material-ui/core', '@material-ui/styles', '@material-ui/icons'],
   },
 };


### PR DESCRIPTION
Add's agreed import blacklist to prevent developers from accidentally including large modules in their application bundle.