### PR TITLE
feat: reduce prettier print width to 100

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -1,6 +1,6 @@
 module.exports = {
   arrowParens: 'always',
-  printWidth: 120,
+  printWidth: 100,
   tabWidth: 2,
   useTabs: false,
   semi: true,

--- a/tslint.js
+++ b/tslint.js
@@ -16,7 +16,10 @@ module.exports = {
       true,
       [
         ['Object', 'Avoid using the `Object` type. Did you mean `object`?'],
-        ['Function', 'Avoid using the `Function` type. Prefer a specific function type, like `() => void`.'],
+        [
+          'Function',
+          'Avoid using the `Function` type. Prefer a specific function type, like `() => void`.',
+        ],
         ['Boolean', 'Avoid using the `Boolean` type. Did you mean `boolean`?'],
         ['Number', 'Avoid using the `Number` type. Did you mean `number`?'],
         ['String', 'Avoid using the `String` type. Did you mean `string`?'],
@@ -358,6 +361,13 @@ module.exports = {
     /**
      * Disallows imports of specified modules. Instead, sub-path imports should be used for these modules.
      */
-    'import-blacklist': [true, 'lodash', 'date-fns', '@material-ui/core', '@material-ui/styles', '@material-ui/icons'],
+    'import-blacklist': [
+      true,
+      'lodash',
+      'date-fns',
+      '@material-ui/core',
+      '@material-ui/styles',
+      '@material-ui/icons',
+    ],
   },
 };


### PR DESCRIPTION
I know this is a bit of a personal taste thing, but I've found a few times that I end up wondering why prettier isn't wrapping a very long line. If this were a lint rule, I'd want it to be even higher, but because prettier aims to fill the full available width, I think it would be better to reduce it slightly.