### PR TITLE
fix: 🐛 Improve eslint config to require fewer changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ module.exports = {
   parserOptions: {
     project: 'tsconfig.json',
     sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   plugins: ['@typescript-eslint', '@typescript-eslint/tslint', 'import', 'jsdoc'],
   rules: {
@@ -60,10 +63,6 @@ module.exports = {
         },
       },
     ],
-    /**
-     * Enforces naming conventions for everything across a codebase
-     */
-    '@typescript-eslint/naming-convention': 'error',
     /**
      * Enforces consistent usage of type assertions
      */
@@ -165,10 +164,6 @@ module.exports = {
      */
     'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
     /**
-     * Enforce camelCase naming convention
-     */
-    camelcase: 'error',
-    /**
      * Ensures `super()` is called in derived class constructors
      */
     'constructor-super': 'error',
@@ -206,7 +201,7 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: false,
+        devDependencies: ['**/__tests__/**/*'],
         optionalDependencies: false,
       },
     ],
@@ -341,10 +336,6 @@ module.exports = {
      * Disallow Initializing to undefined
      */
     'no-undef-init': 'error',
-    /**
-     * Disallow dangling underscores in identifiers
-     */
-    'no-underscore-dangle': 'error',
     /**
      * Disallow control flow statements in finally blocks
      */

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ To use Threads' eslint config, install eslint, the typescript parser, and the re
 yarn add -D @threads/tsconfig eslint
 ```
 
+and add the following `.eslintrc.js` in your project's root directory:
+
+```js
+module.exports = require('@threads/tsconfig/.eslintrc');
+```
+
 In `package.json` add:
 
 ```json
@@ -17,7 +23,7 @@ In `package.json` add:
   ...
   "scripts": {
     ...
-    "lint": "eslint -c @threads/tsconfig/.eslintrc --ext .tsx,.ts ./src/**/*"
+    "lint": "eslint -c .eslintrc.js --ext .tsx,.ts src"
     ...
   }
   ...


### PR DESCRIPTION
Takes out the `no-underscore-dangle`, `camelcase`, and `@typescript/naming-convention` rules as these don't match up with how we were doing variable naming previously, Forbes concerns were correct, and including these rules requires substantial changes. 

I also changed `devDependencies` to allow using dev deps in test files, otherwise it errors on any use of dev dependencies with the `false` config the conversion tool gave us. I also explicitly added the `jsx` parser option. 

Also updated docs around eslint, globbing the files for eslint is handled quite odd, and the `ext` option gets ignored. Instead the better way to do it seems to just be pass it the `ext` options and give it a directory. Also `eslint` didn't like a config within a package after a proper install (I was using a local path to test originally), so changed the docs to reflect this, requiring a `.eslintrc.js` to be made in the project root directory.

These changes make the linter more permissive, so no breaking changes.

Also it's not used anywhere yet, so we wouldn't be breaking anything even if it was.