### PR TITLE
docs: added npm and build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # tsconfig
 
+[![CircleCI](https://circleci.com/gh/ThreadsStyling/tsconfig.svg?style=svg)](https://circleci.com/gh/ThreadsStyling/tsconfig)
+[![npm version](https://badge.fury.io/js/%40threads%2Ftsconfig.svg)](https://badge.fury.io/js/%40threads%2Ftsconfig)
+
 ThreadsStyling tsconfig, tslint, prettier etc. configs. These shared configs are used to set up our TypeScript projects.
 
 ## ESLint


### PR DESCRIPTION
Since this is an open-source project it's always good to add those to the README, it makes it prettier and adds useful information that everyone should have access to while glancing over the repo