### PR TITLE
chore: 🤖 Remove eslint tslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['@typescript-eslint', '@typescript-eslint/tslint', 'import', 'jsdoc'],
+  plugins: ['@typescript-eslint', 'import', 'jsdoc'],
   rules: {
     /**
      * Require that member overloads be consecutive
@@ -364,21 +364,5 @@ module.exports = {
      * Require calls to isNaN() when checking for NaN
      */
     'use-isnan': 'error',
-    /**
-     * The missing rules from tslint that cannot be translated to eslint
-     */
-    '@typescript-eslint/tslint/config': [
-      'error',
-      {
-        rules: {
-          encoding: true,
-          'no-mergeable-namespace': true,
-          'prefer-while': true,
-          'return-undefined': true,
-          'strict-type-predicates': true,
-          'switch-final-break': [true, 'always'],
-        },
-      },
-    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@commitlint/config-conventional": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,14 +369,6 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
-"@typescript-eslint/eslint-plugin-tslint@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-3.6.0.tgz#a121ba852bce025e5de6d9468b9e5532d17f3156"
-  integrity sha512-GY8er0YuyChHNGbisZY6vjdm8Obe+5Y9+c69EV56y//N5lJkUNrmOuAYZu8+h+zXF7/BiHumWhaQOZY0k56IpA==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "3.6.0"
-    lodash "^4.17.15"
-
 "@typescript-eslint/eslint-plugin@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.0.tgz#ba2b6cae478b8fca3f2e58ff1313e4198eea2d8a"
@@ -4255,7 +4247,6 @@ npm@^6.8.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -4270,7 +4261,6 @@ npm@^6.8.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -4289,14 +4279,8 @@ npm@^6.8.0:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
The plugin actually enforces the listed rules with tslint in the background. We've already agreed in the original PR that we are okay with dropping these rules (with the alternative of no-unnecessary-condition being introduced). Removing them here as then the eslint usage will then be entirely removed from tslint, and won't be having to use tslint in the background.