### PR TITLE
fix: 🐛 Use ts no-shadow to stop enum issues, enable void op

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -335,12 +335,8 @@ module.exports = {
     /**
      * Disallow Shadowing of Restricted Names
      */
-    'no-shadow': [
-      'error',
-      {
-        hoist: 'all',
-      },
-    ],
+    'no-shadow': ['off'],
+    '@typescript-eslint/no-shadow': ['error'],
     /**
      * Disallow sparse arrays
      */
@@ -361,10 +357,6 @@ module.exports = {
      * Require let or const instead of var
      */
     'no-var': 'error',
-    /**
-     * Disallow use of the void operator.
-     */
-    'no-void': 'error',
     /**
      * Enforce variables to be declared either separately in functions
      */


### PR DESCRIPTION
The default eslint `no-shadow` is odd with top level enums, so we need to use the typescript version of the rule. Also enables the `void` operator, as it seems useful and I'm not entirely sure why we've explicitly disabled it.