### PR TITLE
chore: 🤖 Set useUnknownInCatchVariables to false

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "useUnknownInCatchVariables": false,
     "declaration": true,
     "lib": ["es2018"]
   }


### PR DESCRIPTION
This is an upcoming change in 4.4 that will set the `e` in `catch(e)` to be `unknown` instead of `any`. This causes a lot of errors. I use Visual Studio Code Insider, which comes with the beta for 4.4 rolled in, so this is flagging a lot of things. Putting it here is a bit of future proofing to make swapping to 4.4 easier, and also should save me. You can find more details
[here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#use-unknown-catch-variables) and also Bloomberg doing the same thing [here](https://github.com/microsoft/TypeScript/issues/45117).

This option prevents any breaking changes.