### PR TITLE
feat: 🎸 Add linter to remove unused imports on pre-commit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,11 @@ module.exports = {
   env: {
     es6: true,
   },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
   extends: [
     /**
      * Turns off all rules that are unnecessary or might conflict with Prettier.
@@ -44,7 +49,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['@typescript-eslint', 'import', 'jsdoc', '@babel'],
+  plugins: ['@typescript-eslint', 'import', 'jsdoc', '@babel', 'unused-imports'],
   rules: {
     /**
      * Require that member overloads be consecutive
@@ -398,5 +403,12 @@ module.exports = {
      * Make exhaustive deps mandatory
      */
     'react-hooks/exhaustive-deps': 'error',
+    /**
+     * Make eslint warn about unused imports
+     */
+    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'warn',
+    'unused-imports/no-unused-vars': 'warn',
   },
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^40.0.0",
     "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-unused-imports": "^3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,13 @@ eslint-plugin-react@^7.32.2:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
+eslint-plugin-unused-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz#d25175b0072ff16a91892c3aa72a09ca3a9e69e7"
+  integrity sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"


### PR DESCRIPTION
Related to [POR-1305](https://threadsstylingltd.atlassian.net/browse/POR-1305?atlOrigin=eyJpIjoiODZiMjdjNDYwYWFiNDc5MzhmZGM0OGVlYzg1MGI3MzQiLCJwIjoiaiJ9)

In this PR I added the [eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports) package which allows eslint to detect unused imports, a thing that we commonly overlook in our reviews.
I also added an auto detect of the react version to eslint because there was a warning when running 'yarn lint'.