### PR TITLE
fix: 🐛 improve redeclaration rules, var usage & react css prop

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,7 +166,11 @@ module.exports = {
     /**
      * Prevents conditionals where the type is always truthy or always falsy
      */
-    '@typescript-eslint/no-unnecessary-condition': ['error', {allowConstantLoopConditions: true}],
+    '@typescript-eslint/no-unnecessary-condition': 'off',
+    /**
+     * Checks for redeclaration of entities with the same name
+     */
+    '@typescript-eslint/no-redeclare': 'off',
     /**
      *
      */
@@ -308,7 +312,11 @@ module.exports = {
     /**
      * Disallow variable redeclaration
      */
-    'no-redeclare': 'error',
+    'no-redeclare': 'off',
+    /**
+     * Disallow var declaration
+     */
+    'no-var': 'off',
     /**
      * Disallow specific imports
      */
@@ -390,5 +398,9 @@ module.exports = {
      * Make exhaustive deps mandatory
      */
     'react-hooks/exhaustive-deps': 'error',
+    /**
+     * Ignore `css` property on components
+     */
+    'react/no-unknown-property': ['error', {ignore: ['css']}],
   },
 };


### PR DESCRIPTION
## In this PR:
- Improve redeclaration rules. In practice we don't need to enforce it via either ESLint TS plugin or ESLint itself, because this is [already checked by the TS compiler](https://eslint.org/docs/latest/rules/no-redeclare#handled_by_typescript). The only downside would be that TS compiler doesn't catch `var` redeclares, but we don't use it usually because hoisting makes code less readable & predictable I've decided to **not allow it.**
- Allow `css` React's property in HTML elements.
- Removed the `no-unnecessary-condition` as it can be unsafe and we already have a few inline disable flags across our products.