### PR TITLE
fix: 🐛 stop using prettier's deprecated jsxBracketSameLine

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -7,5 +7,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   bracketSpacing: false,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
 };


### PR DESCRIPTION
## In this PR:
- Update prettier config stop using prettier's [deprecated `jsxBracketSameLine` option over new `bracketSameLine`](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets).
